### PR TITLE
Datetime parsing bug

### DIFF
--- a/pystac_api/item_search.py
+++ b/pystac_api/item_search.py
@@ -196,7 +196,7 @@ class ItemSearch(STACAPIObjectMixin):
         if isinstance(value, Iterable):
             return '/'.join((map(_format, value)))
 
-        return _format(value),
+        return _format(value)
 
     @staticmethod
     def _format_collections(value: Optional[CollectionsLike]) -> Optional[Collections]:

--- a/tests/cassettes/test_item_search/TestItemSearchParams.test_collection_object.yaml
+++ b/tests/cassettes/test_item_search/TestItemSearchParams.test_collection_object.yaml
@@ -1,0 +1,262 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:29:35 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:29:35 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:32:51 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:32:51 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_item_search/TestItemSearchParams.test_collection_object.yaml
+++ b/tests/cassettes/test_item_search/TestItemSearchParams.test_collection_object.yaml
@@ -259,4 +259,524 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:38:53 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:38:53 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:39:17 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:39:17 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:50:28 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:50:29 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:50:57 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:50:57 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/cassettes/test_item_search/TestItemSearchParams.test_collections_param.yaml
+++ b/tests/cassettes/test_item_search/TestItemSearchParams.test_collections_param.yaml
@@ -1,0 +1,132 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:26:45 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:26:45 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_item_search/TestItemSearchParams.test_mixed_collection_object_and_string.yaml
+++ b/tests/cassettes/test_item_search/TestItemSearchParams.test_mixed_collection_object_and_string.yaml
@@ -259,4 +259,524 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:38:54 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:38:54 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:39:18 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:39:18 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:50:29 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:50:30 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:50:58 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:51:00 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/cassettes/test_item_search/TestItemSearchParams.test_mixed_collection_object_and_string.yaml
+++ b/tests/cassettes/test_item_search/TestItemSearchParams.test_mixed_collection_object_and_string.yaml
@@ -1,0 +1,262 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:29:36 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:29:37 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOyZbU/bOhTHv4qVFxNI9CEBCcabq0LvSiUoqHBB04Qik5yk3k3izHZbOsR333GS
+        UqekpbCWV9WmINvn/M/PzyfNk+XxJOAiljfcOv5hDZRKjxuN8Xhc5ykkIZP1BFRDpuA1eOjRlNUC
+        oGooQNbshl1vNrQ/PgRYex/15lTuNz/uHgL/KXmykoDr8TjmSc3J3AX8QokoAk8xnsiZglTU0151
+        LsLcHX21S71ZewBF6/Zcl1dw0MG0WU0CFd7gY77Y9RRJ3x85YBD57+thPjqJgkf1flgulHW/Z/kg
+        PcFSPbzWsdWSSlCg5F8q1IBcJm2IaeITnECZUsVoRFhMQxAT8muon7qRJjSaSCaJ4jxCDuajEM2F
+        sBix5H+JK/fJGggIsElzSgQF7tc8qmjEw5ocebVUcL9e+NVBA6C3gAhdJEQBFhRTEWDxuihOUl2i
+        aRoxFMIeNLJl9rz3N7EE58qI1S+K64ylZ8TomxgxD2p6Ioy4l7g9WlddomeQBUXMTYDUByqOXtNw
+        E0aDYM0whkTNgejF18gkPkZQ3t05hI8uRvTTksl6B6AqfLnukykaEe4pSdWRG9kqnTENWOQbNOe5
+        FTkipza5sTdKFHv+wT49WMhycdo+2G8dkN5Jq79ZEO7bNrUXg1y2bbtlk/Prm81yTN7g+P5JHDge
+        +2+Mxz5y3HY3PhxLMb5/CobEw4klENm4czw3FP5CoOvCsoZTZJ+STr/9KWCOGzn0bSiHnDutzwKy
+        vZWA7NONAiWULT7qeq3u1WbXL32kwtX5qFvcPAvWsbYj+mIm7eKG2twUpdQDTI0PF0+PtuiBIofr
+        zwrCUEBIFbwEn9YUV/80LSjXLmHAzJ4+sIgpBpgLPlkpFTQGBSLPDBMsZBdvnHLJsrgjGg0hby2n
+        qG0I6DBS5JbBuI6Gha+fVxt0pmEGUda5EUMgeKlzgc8irqGnsBnfRbDZkKzyqZDu4esajdhv8Emb
+        BQEISDwgtxBCnj2RbuLDoxEs8UfMXPFtPCpXlb3DeRK5IhlKloSkIwCXqE7Ne90+SbH1wvsG2Wjv
+        2F+/Hu6WIo/Lke+6ZCcX+KLdd/+CQ0fXFNd3BUaH8koA5xWBdv2SOVYB5DPQTQJBBULszEZ2l+D7
+        EL6LKB2fB6SHC7rGCsM90tcPjZT38EEnUQZLNt3u1NwdQWiXE0AzqjGdO71+Z62cGV5OeoLbYAVQ
+        ZyVQB1E7J1Wo32gkp0t7BvyfwMjmbAXaLN8W7lA3GmFNicKzIlArFMzDbTkU5m6js9rS+TKrfa10
+        wXH8sOnVboqLBhwgbDAP8JJHhWQHkD6cGFphXmOIFDYV3idUDSZ4qiG0ofAwqzVUDNuqQVIxvnAP
+        AFvJlb4GRDZ/5oDNLNx0ZmEOXrVGRbRsf9qGuBwzYa783GCRpzPn6cx7OlWerT65vSVXPKKC/Z7v
+        ncT7eDQydV6bLxI9Wyo6mBc9W0X0bKnoYF70bDXRpd0fzHf/bKXuV2zCOeFlW3iBgvV8j//21ppJ
+        lPe5UbfNIrZZxDaL2GYR2yxim0Vss4htFoFZxMv3uOk3iqI4+6VqWrHWn0Hw3PBd/I9JAUtY9rvM
+        P07TaTYd++gFpsLI3ObYSrpt0i63LsK837P05zsXHhXgwa6tj39YwNEH+X7in+nnvqnlCK/jfN6M
+        L3zm3qn+omc9/wEAAP//AwCX/i7RWB4AAA==
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:32:52 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://eod-catalog-svc-prod.astraea.earth/collections/landsat8_l1tp
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAOxYbW/bNhD+K4KAAQkQvVCyFDtDPzjpFhhI0yx2UWBBYdDS2VZHiRpJ20mL/vcd
+        JctmWjuZXQ/74i+WTJ549zz3Qh6/2pQxvoDUvlBiBmc2lRKUtC++2peR/h3NipQBHTFoJIBfjGiR
+        oszDVzvhec6LYUFznLeLTNhn9vIPfv/tUyW+SQiHJxK1hr7rn9nGq+AM9Np2ShW1cQGVKVath0qt
+        yHKsW6DC6hVjQQWk1slt7/4UR9sRcdrnnSK3TkI/P0UV6qnU32U5nYCnsvH4V4uWJcsSqjJevJkA
+        rwdLwccZgzcJ47PU4aXK8uwLMvINl5jO8tGQUTGBzWSsrOVzEPMMFqi3FFC9GbYP9DoFzRgaelOt
+        9p15n0uYaIWX8c6ky0UmSGzwHm/mfSW3J/Ux2t6fcqEWdA4G//2P2gEEZ0kUxw6JI3JYJ1yGO3My
+        EQCFQUm4mZJGbE9GQsR8rZfAZxSGTtTxD4w82Bn5iM3AAB5sBr6U2hN3gHgvcQV8tKLAiUhwYNh/
+        dLfifsXev3+0Fhc7jFWtnZ2B+WH4orXZF7XQnq5ooQ/uMQsdKw5jJz4PD+wJsjPmhFOpKDNwk824
+        14J7Ytcl5wNTgtbBeLJc0KMguORMbwqtMHJaB69HZHdWmC6+gUnKFlZWgvuSolkZTEHklBlFetC7
+        759WiUtI5PsOCSJy4GL1bnDzyh6Zg6LfG30neDpLlPWumVvZouBReSWjWbHeiSWiYq9oUc1eu20D
+        7leLbNuAO7tHfCbETBq+7WwJ+EZuT9d20Parag3txjAOHRK2WweO7fO9zh+BGdrn288fwU9E9vmL
+        5w8d2gHxz50g6ByaE+Lvl+/EzHf/hXwnP5Hv/gv5Xh3K/FjnOyEHP5y0d2alpOahrL2ZkVqooYNE
+        Kzrq15fpaCPiO1okU8FzhJLok5kf4sYYa/AkOhT47u31HsWuW0wYWFccxuMsyaB4reyhohRkIrJS
+        G4aTN5pYqhDmFWcMEj2MXh5kIPBxJyDJpB4agBC4gjVGGqz1R+9LEBVGjBU9avU0BcI6eX/TO7X0
+        wA+R1IdCctEE1NJUNBGN1wTIEtejdUke8UcE/uCQto5bp6N/63f9+umTruKQl1zU8lmhsGXS7w8P
+        duCT0EFHkfaARBdR58IP3DAM/7TPihlj+C1+PKZ5xp56qc6aGlLbbkYHS4ZXWHEmMyWHjKhSD6IJ
+        w2OTe2xyj03usck9NrnHJvfY5B6b3GOTe2xyj03usck9Nrn/T5OLVmGbWVXKt29vHOL6th4s/qr5
+        nQoY49xUqVJeeB7w1EEUlPGJI+eJgwhSF3dFQYG62DapqZesumPpfd8BCmA6UYGN7bXRRmON7TTB
+        treers01iPM+S65r9R5WrXSXGL7YPhv7w2rgP9EnODe13S//HlLXdsY93XHrDYE3lw9V5ExA6aCp
+        DWxEtnmj18z/e5NlmT66XEy8ZWxJrwktd6pytuKmCT1D+XrECNbqI53K2PhKdJaZDkjHPEtB1NFK
+        lRLZaLa8sfnQv+57t91+t7mGWdcGPWUbyVRWpwQQdpMQXGiKZoIZuJbcujM5ke6Ez70K/HOddygE
+        ChWOjA37+aCpNAG5UdVisXDL6isXi5dXm6ekh+qBMfSZUxUX8eTpAiI9EhOs5fGwX0LyS+D3pwBq
+        eMXzUVZAOqyvmp6Gy7PQ8AaUAjH87fZ6TtwyHW/A0c3pF15YH2GE+SjmyImBp/vxGXlTLtVWtnhB
+        F7ICUbkQ0Vb++z0DljYsYHSqDKSLhQqwBkJ1x7Ea1QVcF8hhou9A6sulM3sd9M+lEwG4SqrtwcN6
+        Mqzuy2QT+jraneUVVCOBi8oatI5Q3xlhyXSD7Slhf/sHAAD//wMAd687srohAAA=
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-Astraea-Catalog-Client
+      - Authorization, Content-Type, X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 08 Apr 2021 12:32:52 GMT
+      Server:
+      - akka-http/10.2.3
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -72,7 +72,6 @@ class TestItemSearchParams:
         search = ItemSearch(url=ASTRAEA_URL, datetime='2020-02-01T00:00:00Z/..')
         assert search.request.json['datetime'] == '2020-02-01T00:00:00Z/..'
 
-    @pytest.mark.xfail(reason="Parsing of single datetime objects is broken")
     def test_single_datetime_object(self):
         start = datetime(2020, 2, 1, 0, 0, 0, tzinfo=tzutc())
 
@@ -95,7 +94,6 @@ class TestItemSearchParams:
         search = ItemSearch(url=ASTRAEA_URL, datetime=(start, None))
         assert search.request.json['datetime'] == '2020-02-01T00:00:00Z/..'
 
-    @pytest.mark.xfail(reason="Parsing of single datetime objects is broken")
     def test_localized_datetime_converted_to_utc(self):
         # Localized datetime input (should be converted to UTC)
         start_localized = datetime(2020, 2, 1, 0, 0, 0, tzinfo=gettz('US/Eastern'))

--- a/tests/test_item_search.py
+++ b/tests/test_item_search.py
@@ -23,35 +23,28 @@ INTERSECTS_EXAMPLE = {
 }
 
 
-class TestItemSearch:
-    """Use the API.search method instead of ItemSearch directly to make auth handling easier."""
+class TestItemSearchParams:
     @pytest.fixture(scope='function')
     def astraea_api(self):
         api_content = read_data_file('astraea_api.json', parse_json=True)
         return API.from_dict(api_content)
 
-    def test_method(self):
-        # Default method should be POST...
-        search = ItemSearch(url=ASTRAEA_URL)
-        assert search.method == 'POST'
-
-        # "method" argument should take precedence over presence of "intersects"
-        search = ItemSearch(url=ASTRAEA_URL, method='GET', intersects=INTERSECTS_EXAMPLE)
-        assert search.method == 'GET'
-
-    def test_bbox_param(self):
+    def test_tuple_bbox(self):
         # Tuple input
         search = ItemSearch(url=ASTRAEA_URL, bbox=(-104.5, 44.0, -104.0, 45.0))
         assert search.request.json['bbox'] == (-104.5, 44.0, -104.0, 45.0)
 
+    def test_list_bbox(self):
         # List input
         search = ItemSearch(url=ASTRAEA_URL, bbox=[-104.5, 44.0, -104.0, 45.0])
         assert search.request.json['bbox'] == (-104.5, 44.0, -104.0, 45.0)
 
+    def test_string_bbox(self):
         # String Input
         search = ItemSearch(url=ASTRAEA_URL, bbox='-104.5,44.0,-104.0,45.0')
         assert search.request.json['bbox'] == (-104.5, 44.0, -104.0, 45.0)
 
+    def test_generator_bbox(self):
         # Generator Input
         def bboxer():
             yield from [-104.5, 44.0, -104.0, 45.0]
@@ -59,78 +52,101 @@ class TestItemSearch:
         search = ItemSearch(url=ASTRAEA_URL, bbox=bboxer())
         assert search.request.json['bbox'] == (-104.5, 44.0, -104.0, 45.0)
 
-    def test_datetime_param(self):
+    def test_single_string_datetime(self):
         # Single timestamp input
         search = ItemSearch(url=ASTRAEA_URL, datetime='2020-02-01T00:00:00Z')
         assert search.request.json['datetime'] == '2020-02-01T00:00:00Z'
 
+    def test_range_string_datetime(self):
         # Timestamp range input
         search = ItemSearch(url=ASTRAEA_URL, datetime='2020-02-01T00:00:00Z/2020-02-02T00:00:00Z')
         assert search.request.json['datetime'] == '2020-02-01T00:00:00Z/2020-02-02T00:00:00Z'
 
+    def test_list_of_strings_datetime(self):
         # Timestamp list input
         search = ItemSearch(url=ASTRAEA_URL, datetime=['2020-02-01T00:00:00Z', '2020-02-02T00:00:00Z'])
         assert search.request.json['datetime'] == '2020-02-01T00:00:00Z/2020-02-02T00:00:00Z'
 
+    def test_open_range_string_datetime(self):
         # Open timestamp range input
         search = ItemSearch(url=ASTRAEA_URL, datetime='2020-02-01T00:00:00Z/..')
         assert search.request.json['datetime'] == '2020-02-01T00:00:00Z/..'
 
+    @pytest.mark.xfail(reason="Parsing of single datetime objects is broken")
+    def test_single_datetime_object(self):
         start = datetime(2020, 2, 1, 0, 0, 0, tzinfo=tzutc())
-        end = datetime(2020, 2, 2, 0, 0, 0, tzinfo=tzutc())
 
         # Single datetime input
         search = ItemSearch(url=ASTRAEA_URL, datetime=start)
         assert search.request.json['datetime'] == '2020-02-01T00:00:00Z'
 
+    def test_list_of_datetimes(self):
+        start = datetime(2020, 2, 1, 0, 0, 0, tzinfo=tzutc())
+        end = datetime(2020, 2, 2, 0, 0, 0, tzinfo=tzutc())
+
         # Datetime range input
         search = ItemSearch(url=ASTRAEA_URL, datetime=[start, end])
         assert search.request.json['datetime'] == '2020-02-01T00:00:00Z/2020-02-02T00:00:00Z'
+
+    def test_open_list_of_datetimes(self):
+        start = datetime(2020, 2, 1, 0, 0, 0, tzinfo=tzutc())
 
         # Open datetime range input
         search = ItemSearch(url=ASTRAEA_URL, datetime=(start, None))
         assert search.request.json['datetime'] == '2020-02-01T00:00:00Z/..'
 
+    @pytest.mark.xfail(reason="Parsing of single datetime objects is broken")
+    def test_localized_datetime_converted_to_utc(self):
         # Localized datetime input (should be converted to UTC)
         start_localized = datetime(2020, 2, 1, 0, 0, 0, tzinfo=gettz('US/Eastern'))
         search = ItemSearch(url=ASTRAEA_URL, datetime=start_localized)
         assert search.request.json['datetime'] == '2020-02-01T05:00:00Z'
 
-    @pytest.mark.vcr
-    def test_collections_param(self, astraea_api):
+    def test_single_collection_string(self):
         # Single ID string
         search = ItemSearch(url=ASTRAEA_URL, collections='naip')
         assert search.request.json['collections'] == ('naip',)
 
+    def test_multiple_collection_string(self):
         # Comma-separated ID string
         search = ItemSearch(url=ASTRAEA_URL, collections='naip,landsat8_l1tp')
         assert search.request.json['collections'] == ('naip', 'landsat8_l1tp')
 
+    def test_list_of_collection_strings(self):
         # List of ID strings
         search = ItemSearch(url=ASTRAEA_URL, collections=['naip', 'landsat8_l1tp'])
         assert search.request.json['collections'] == ('naip', 'landsat8_l1tp')
 
+    def test_generator_of_collection_strings(self):
         # Generator of ID strings
         def collectioner():
             yield from ['naip', 'landsat8_l1tp']
+
         search = ItemSearch(url=ASTRAEA_URL, collections=collectioner())
         assert search.request.json['collections'] == ('naip', 'landsat8_l1tp')
 
+    @pytest.mark.vcr
+    def test_collection_object(self, astraea_api):
         collection = astraea_api.get_child('landsat8_l1tp')
 
         # Single pystac.Collection
         search = ItemSearch(url=ASTRAEA_URL, collections=collection)
         assert search.request.json['collections'] == ('landsat8_l1tp',)
 
+    @pytest.mark.vcr
+    def test_mixed_collection_object_and_string(self, astraea_api):
+        collection = astraea_api.get_child('landsat8_l1tp')
+
         # Mixed list
         search = ItemSearch(url=ASTRAEA_URL, collections=[collection, 'naip'])
         assert search.request.json['collections'] == ('landsat8_l1tp', 'naip')
 
-    def test_ids_param(self):
+    def test_single_id_string(self):
         # Single ID
         search = ItemSearch(url=ASTRAEA_URL, ids='m_3510836_se_12_060_20180508_20190331')
         assert search.request.json['ids'] == ('m_3510836_se_12_060_20180508_20190331',)
 
+    def test_multiple_id_string(self):
         # Comma-separated ID string
         search = ItemSearch(
             url=ASTRAEA_URL,
@@ -141,6 +157,7 @@ class TestItemSearch:
             'm_3510840_se_12_060_20180504_20190331'
         )
 
+    def test_list_of_id_strings(self):
         # List of IDs
         search = ItemSearch(
             url=ASTRAEA_URL,
@@ -154,6 +171,7 @@ class TestItemSearch:
             'm_3510840_se_12_060_20180504_20190331'
         )
 
+    def test_generator_of_id_string(self):
         # Generator of IDs
         def ids():
             yield from [
@@ -170,14 +188,31 @@ class TestItemSearch:
             'm_3510840_se_12_060_20180504_20190331'
         )
 
-    def test_intersects_param(self):
+    def test_intersects_dict(self):
         # Dict input
         search = ItemSearch(url=SEARCH_URL, intersects=INTERSECTS_EXAMPLE)
         assert search.request.json['intersects'] == INTERSECTS_EXAMPLE
 
+    def test_intersects_json_string(self):
         # JSON string input
         search = ItemSearch(url=SEARCH_URL, intersects=json.dumps(INTERSECTS_EXAMPLE))
         assert search.request.json['intersects'] == INTERSECTS_EXAMPLE
+
+
+class TestItemSearch:
+    @pytest.fixture(scope='function')
+    def astraea_api(self):
+        api_content = read_data_file('astraea_api.json', parse_json=True)
+        return API.from_dict(api_content)
+
+    def test_method(self):
+        # Default method should be POST...
+        search = ItemSearch(url=ASTRAEA_URL)
+        assert search.method == 'POST'
+
+        # "method" argument should take precedence over presence of "intersects"
+        search = ItemSearch(url=ASTRAEA_URL, method='GET', intersects=INTERSECTS_EXAMPLE)
+        assert search.method == 'GET'
 
     @pytest.mark.vcr
     def test_results(self):


### PR DESCRIPTION
**Description:**

After #17 and #18 the format of `ItemSearch.request.json["datetime"]` is inconsistent. In most cases, it is a string timestamp, which is the desired behavior. However, if a single `datetime.datetime` instance is passed to `ItemSearch` when instantiating, then `ItemSearch.request.json["datetime"]` is a `tuple` containing the timetamp string.

This PR starts by breaking the param tests up to be more atomic so it's easier to see where this is failing. The relevant failing test here is `tests/test_item_search.py::TestItemSearchParams::test_single_datetime_object`, but `tests/test_item_search.py::TestItemSearchParams::test_localized_datetime_converted_to_utc` also fails because it uses a single `datetime.datetime` argument. 

```console
$ pytest --block-network --record-mode all tests/test_item_search.py::TestItemSearchParams -rsx
=========================================================================================================== test session starts ============================================================================================================
platform darwin -- Python 3.8.6, pytest-5.4.3, py-1.10.0, pluggy-0.13.1
rootdir: /Users/jduckworth/Code/pystac-api
plugins: recording-0.11.0, cov-2.11.1
collected 24 items

tests/test_item_search.py ........x..x............                                                                                                                                                                                   [100%]

========================================================================================================= short test summary info ==========================================================================================================
XFAIL tests/test_item_search.py::TestItemSearchParams::test_single_datetime_object
  Parsing of single datetime objects is broken
XFAIL tests/test_item_search.py::TestItemSearchParams::test_localized_datetime_converted_to_utc
  Parsing of single datetime objects is broken
====================================================================================================== 22 passed, 2 xfailed in 1.88s =======================================================================================================
```

Both of these tests have been marked with `pytest.mark.xfail` until the fix is in place, and I'll add a commit to this PR with the fix shortly.

**PR Checklist:**

- [x] Code is formatted
- [ ] ~Tests pass~ There are still failing tests unrelated to this.
- [ ] ~Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac-api-client/blob/main/CHANGELOG.md)~ I don't think a CHANGELOG entry is needed here